### PR TITLE
feat(entities): Rename selectors to Detail/List convention

### DIFF
--- a/src/entities/__tests__/selectors.test.js
+++ b/src/entities/__tests__/selectors.test.js
@@ -49,7 +49,7 @@ describe('getEntity', () => {
   )
 })
 
-describe('getEntityItem', () => {
+describe('getDetail', () => {
   beforeEach(() => {
     state = getEntitiesState()
   })
@@ -58,7 +58,7 @@ describe('getEntityItem', () => {
     'throws on bad arguments',
     opts => {
       expect(() =>
-        selectors.getEntityItem(opts.state, opts.entity, opts.id),
+        selectors.getDetail(opts.state, opts.entity, opts.id),
       ).toThrow()
     },
     [
@@ -73,7 +73,7 @@ describe('getEntityItem', () => {
     'returns undefined',
     opts => {
       expect(
-        selectors.getEntityItem(opts.state, opts.entity, opts.id),
+        selectors.getDetail(opts.state, opts.entity, opts.id),
       ).toBeUndefined()
     },
     [
@@ -85,11 +85,11 @@ describe('getEntityItem', () => {
   )
 
   cases(
-    'returns entityItem',
+    'returns entityDetail',
     opts => {
-      const entityItem = opts.state[opts.entity][opts.id]
-      expect(selectors.getEntityItem(opts.state, opts.entity, opts.id)).toBe(
-        entityItem,
+      const entityDetail = opts.state[opts.entity][opts.id]
+      expect(selectors.getDetail(opts.state, opts.entity, opts.id)).toBe(
+        entityDetail,
       )
     },
     [
@@ -100,7 +100,7 @@ describe('getEntityItem', () => {
   )
 })
 
-describe('getEntityItemList', () => {
+describe('getList', () => {
   beforeEach(() => {
     state = getEntitiesState()
   })
@@ -109,7 +109,7 @@ describe('getEntityItemList', () => {
     'throws on bad arguments',
     opts => {
       expect(() =>
-        selectors.getEntityItemList(opts.state, opts.entity, opts.ids),
+        selectors.getList(opts.state, opts.entity, opts.ids),
       ).toThrow()
     },
     [
@@ -129,9 +129,7 @@ describe('getEntityItemList', () => {
   cases(
     'returns no results as empty list',
     opts => {
-      expect(
-        selectors.getEntityItemList(opts.state, opts.entity, opts.ids),
-      ).toEqual([])
+      expect(selectors.getList(opts.state, opts.entity, opts.ids)).toEqual([])
     },
     [
       {state: {}, entity: 'team', ids: [1]},
@@ -142,13 +140,9 @@ describe('getEntityItemList', () => {
   )
 
   cases(
-    'returns entityItemList',
+    'returns entityDetailList',
     opts => {
-      const result = selectors.getEntityItemList(
-        opts.state,
-        opts.entity,
-        opts.ids,
-      )
+      const result = selectors.getList(opts.state, opts.entity, opts.ids)
       expect(result).toEqual(opts.result)
     },
     [

--- a/src/entities/selectors.js
+++ b/src/entities/selectors.js
@@ -18,20 +18,20 @@ export default ({schemas}) => {
       return state[entity] || {}
     })
 
-  const getEntityItem = t
+  const getDetail = t
     .func([EntitiesState, EntityName, EntityItemId], t.maybe(EntityItem))
     .of((state = initialState, entity, entityId) => {
       return getEntity(state, entity)[entityId]
     })
 
-  const getEntityItemList = t
+  const getList = t
     .func([EntitiesState, EntityName, t.list(EntityItemId)], EntityItemList)
     .of((state = initialState, entity, entityIdList) => {
       const ids = entityIdList || Object.keys(getEntity(state, entity))
-      const entityItemList = ids.map(entityId =>
-        getEntityItem(state, entity, entityId),
+      const entityDetailList = ids.map(entityId =>
+        getDetail(state, entity, entityId),
       )
-      return entityItemList.filter(EntityItem.is)
+      return entityDetailList.filter(EntityItem.is)
     })
 
   const getDenormalizedDetail = t
@@ -50,8 +50,8 @@ export default ({schemas}) => {
   return {
     initialState,
     getEntity,
-    getEntityItem,
-    getEntityItemList,
+    getDetail,
+    getList,
     getDenormalizedDetail,
     getDenormalizedList,
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Entities selectors for getting an item or list of items is being renamed to a previous convention of detail and list. The new selectors names getDetail and getList match the resource selectors.

<!-- Why are these changes necessary? -->

**Why**: To make the API of resource and entities selectors match.

<!-- How were these changes implemented? -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

