### PR TITLE
fix: Set redux-saga-thunk name correctly

### DIFF
--- a/src/modules/resource/__tests__/actions.test.js
+++ b/src/modules/resource/__tests__/actions.test.js
@@ -18,7 +18,7 @@ test('resourceCreateRequest', () => {
       meta: expect.objectContaining({
         resource: 'resourceName',
         entityType: 'schemaName',
-        thunk: `resourceNameCreate`,
+        thunk: {name: `resourceNameCreate`},
       }),
     }),
   )
@@ -94,7 +94,7 @@ test('resourceListCreateRequest', () => {
       meta: expect.objectContaining({
         resource: 'resourceName',
         entityType: 'schemaName',
-        thunk: `resourceNameListCreate`,
+        thunk: {name: `resourceNameListCreate`},
       }),
     }),
   )
@@ -169,6 +169,7 @@ test('resourceListReadRequest', () => {
       },
       meta: expect.objectContaining({
         resource: 'resourceName',
+        thunk: {name: `resourceNameListRead`},
       }),
     }),
   )
@@ -242,6 +243,7 @@ test('resourceDetailReadRequest', () => {
       },
       meta: expect.objectContaining({
         resource: 'resourceName',
+        thunk: {name: 'resourceNameDetailRead'},
       }),
     }),
   )
@@ -321,6 +323,7 @@ test('resourceUpdateRequest', () => {
       },
       meta: expect.objectContaining({
         resource: 'resourceName',
+        thunk: {name: 'resourceNameUpdate'},
       }),
     }),
   )
@@ -398,7 +401,7 @@ test('resourceDeleteRequest', () => {
       meta: expect.objectContaining({
         entityType: 'schemaName',
         resource: 'resourceName',
-        thunk: `resourceNameDelete`,
+        thunk: {name: 'resourceNameDelete'},
       }),
     }),
   )

--- a/src/modules/resource/actions.js
+++ b/src/modules/resource/actions.js
@@ -8,7 +8,7 @@ export const resourceCreateRequest = (resource, data, entityType) => ({
   meta: {
     resource,
     entityType,
-    thunk: `${resource}Create`,
+    thunk: {name: `${resource}Create`},
   },
 })
 
@@ -62,7 +62,7 @@ export const resourceListCreateRequest = (resource, data, entityType) => ({
   meta: {
     resource,
     entityType,
-    thunk: `${resource}ListCreate`,
+    thunk: {name: `${resource}ListCreate`},
   },
 })
 
@@ -116,7 +116,7 @@ export const resourceListReadRequest = (resource, params, entityType) => ({
   meta: {
     resource,
     entityType,
-    thunk: `${resource}ListRead`,
+    thunk: {name: `${resource}ListRead`},
   },
 })
 
@@ -170,7 +170,7 @@ export const resourceDetailReadRequest = (resource, needle, entityType) => ({
   meta: {
     entityType,
     resource,
-    thunk: `${resource}DetailRead`,
+    thunk: {name: `${resource}DetailRead`},
   },
 })
 
@@ -224,7 +224,7 @@ export const resourceUpdateRequest = (resource, needle, data, entityType) => ({
   meta: {
     entityType,
     resource,
-    thunk: `${resource}Update`,
+    thunk: {name: `${resource}Update`},
   },
 })
 
@@ -278,7 +278,7 @@ export const resourceDeleteRequest = (resource, needle, entityType) => ({
   meta: {
     entityType,
     resource,
-    thunk: `${resource}Delete`,
+    thunk: {name: `${resource}Delete`},
   },
 })
 


### PR DESCRIPTION
In redux-saga-thunk v0.7.0 release a change was made to update the meta.thunk
value to be a object that holds name, key, type props with optional id prop.
Previously the action was setting the thunk name by meta.thunk = 'stringName'
and that was resulting in the meta.thunk object having properties for each char
in the thunk name string. This updates the actions to set the name by passing an
object like: meta.thunk = {name: 'stringName'}

## Future Related Changes
In the future we should update the name to be passed without the resource
path and instead set the name and id. Here is an example:

   ```js
   meta.thunk = {
     name: 'DetailRead',
     id: 'user/123',
   }
   ```

This would allow for the new redux-saga-thunk selectors id arg to be used like
so:

   ```js
   pending(state, 'DetailRead', 'user/123')
   ```
