### PR TITLE
Return requestResult & entities to ResourceLoader child render prop

### DIFF
--- a/src/helpers/entities/components/EntityList.js
+++ b/src/helpers/entities/components/EntityList.js
@@ -11,8 +11,9 @@ export default ({entities}) => {
 
   EntityList.propTypes = {
     children: PropTypes.func,
-    entityIds: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-      .isRequired,
+    entityIds: PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    ).isRequired,
     entityType: PropTypes.string.isRequired,
     entityList: PropTypes.arrayOf(PropTypes.object),
   }

--- a/src/helpers/resource/components/ResourceLoader.js
+++ b/src/helpers/resource/components/ResourceLoader.js
@@ -9,7 +9,7 @@ import {
 
 class ResourceLoader extends React.Component {
   state = {
-    result: null,
+    requestResult: null,
     error: null,
     loading: false,
   }
@@ -20,10 +20,18 @@ class ResourceLoader extends React.Component {
     }
   }
 
+  getRequesResultValuesObj() {
+    const {requestResult} = this.state
+    const entities = requestResult && requestResult.entities
+    const result = requestResult && requestResult.data
+
+    return {entities, requestResult, result}
+  }
+
   getStatusObj() {
     const error = !!this.state.error
     const loading = this.state.loading
-    const success = !!this.state.result && !loading
+    const success = !!this.state.requestResult && !loading
     const initial = !error && !loading && !success
 
     return {error, initial, loading, success}
@@ -44,21 +52,21 @@ class ResourceLoader extends React.Component {
     return renderLoading ? renderLoading() : null
   }
 
-  getStatusViewSuccess(result) {
+  getStatusViewSuccess(result, requestResultValues) {
     const {renderSuccess} = this.props
-    return renderSuccess ? renderSuccess(result) : null
+    return renderSuccess ? renderSuccess(result, requestResultValues) : null
   }
 
   getStatusView() {
-    const {error, result} = this.state
     const status = this.getStatusObj()
 
     if (status.error) {
-      return this.getStatusViewError(error)
+      return this.getStatusViewError(this.state.error)
     } else if (status.loading) {
       return this.getStatusViewLoading()
     } else if (status.success) {
-      return this.getStatusViewSuccess(result)
+      const {result, ...requestResultValues} = this.getRequesResultValuesObj()
+      return this.getStatusViewSuccess(result, requestResultValues)
     } else if (status.initial) {
       return this.getStatusViewInitial()
     }
@@ -79,8 +87,16 @@ class ResourceLoader extends React.Component {
   }
 
   loadResourceSuccess = payload => {
+    const requestResult = {
+      api: payload.api,
+      data: payload.data,
+      entities: payload.entities,
+      entityType: payload.entityType,
+      resource: payload.resource,
+    }
+
     this.setState({
-      result: payload.data,
+      requestResult,
       error: null,
       loading: false,
     })
@@ -122,7 +138,7 @@ class ResourceLoader extends React.Component {
 
   resetState = () => {
     this.setState({
-      result: null,
+      requestResult: null,
       error: null,
       loading: false,
     })
@@ -133,7 +149,9 @@ class ResourceLoader extends React.Component {
       throw new Error('Children should be a Function!')
     }
 
-    const {result, error} = this.state
+    const {error} = this.state
+    const {result, ...requestResultValues} = this.getRequesResultValuesObj()
+
     return this.props.children({
       onEventLoadResource: this.onEventLoadResource,
       loadResource: this.loadResource,
@@ -141,6 +159,7 @@ class ResourceLoader extends React.Component {
       statusView: this.getStatusView(),
       error,
       result,
+      ...requestResultValues,
     })
   }
 }

--- a/src/helpers/resource/components/ResourceLoader.js
+++ b/src/helpers/resource/components/ResourceLoader.js
@@ -150,6 +150,7 @@ class ResourceLoader extends React.Component {
     }
 
     const {error} = this.state
+    const {entityType} = this.props
     const {result, ...requestResultValues} = this.getRequesResultValuesObj()
 
     return this.props.children({
@@ -158,6 +159,7 @@ class ResourceLoader extends React.Component {
       status: this.getStatusObj(),
       statusView: this.getStatusView(),
       error,
+      entityType,
       result,
       ...requestResultValues,
     })


### PR DESCRIPTION
# Overview
To support address the needs explained in #31 `requestResult` and `entities` props have been added to the object passed to `ResourceLoader` component child render prop.

# Added Properties
## requestResult
This holds multiple values from the resource request success action payload. It can be useful for debugging or implementing extra functions such as pagination (uses `api` to get page values from backend).
```js
const requestResult = {
  api: payload.api,
  data: payload.data,
  entities: payload.entities,
  entityType: payload.entityType,
  resource: payload.resource,
}
```
## entities
This holds the value returned in the resource request success action payload object's `entities` property. For detail requests the `entities` value will be a single id (string|number). For list requests the `entities` value will be an array of entity IDs. If no `entityType` is passed (or for some other reason resource isn't normalized into entities) the `entities` value will be `null`.

# Example Usage
```js
const MemberListContainer = () =>
  <ResourceListLoader resource="member" entityType="member" loadOnMount>
    {({ status, entities }) =>
      <Block>
        {status.pending && <Spinner />}
        {status.success && 
          entities &&
          <EntityList entityIds={entities} entityType="member">
            {memberList => <MemberList memberList={memberList} />}
          </EntityList>}
      </Block>}
  </ResourceListLoader>;
```