### PR TITLE
Add `status.done` to ResourceLoader render prop args and updat react-redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-lifecycles-compat": "^3.0.4",
-    "react-redux": "^5.0.5",
+    "react-redux": "^5.0.7",
     "redux": "^3.7.2",
     "redux-saga": "^0.16.0",
     "redux-saga-thunk": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "cz-conventional-changelog": "^2.1.0",
     "jest-in-case": "^1.0.2",
     "normalizr": "^3.2.4",
-    "prettier": "^1.13.5",
     "react-testing-library": "^3.1.3",
     "redux-mock-store": "^1.5.1",
     "uptrend-scripts": "^0.40.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "normalizr": "^3.2.4",
     "react-testing-library": "^3.1.3",
     "redux-mock-store": "^1.5.1",
-    "uptrend-scripts": "^0.39.0"
+    "uptrend-scripts": "^0.40.0"
   },
   "eslintIgnore": [
     "node_modules",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "cz-conventional-changelog": "^2.1.0",
     "jest-in-case": "^1.0.2",
     "normalizr": "^3.2.4",
+    "prettier": "^1.13.5",
     "react-testing-library": "^3.1.3",
     "redux-mock-store": "^1.5.1",
     "uptrend-scripts": "^0.40.0"

--- a/src/helpers/resource/components/ResourceLoader.js
+++ b/src/helpers/resource/components/ResourceLoader.js
@@ -52,8 +52,9 @@ class ResourceLoader extends React.Component {
     const loading = this.state.loading
     const success = !!this.state.requestResult && !loading
     const initial = !error && !loading && !success
+    const done = error || success
 
-    return {error, initial, loading, success}
+    return {done, error, initial, loading, success}
   }
 
   getStatusViewError(error) {
@@ -216,7 +217,4 @@ const mapDispatchToProps = {
   requestListRead: resourceListReadRequest,
 }
 
-export default connect(
-  null,
-  mapDispatchToProps,
-)(ResourceLoader)
+export default connect(null, mapDispatchToProps)(ResourceLoader)

--- a/src/helpers/resource/components/ResourceLoader.js
+++ b/src/helpers/resource/components/ResourceLoader.js
@@ -217,4 +217,7 @@ const mapDispatchToProps = {
   requestListRead: resourceListReadRequest,
 }
 
-export default connect(null, mapDispatchToProps)(ResourceLoader)
+export default connect(
+  null,
+  mapDispatchToProps,
+)(ResourceLoader)

--- a/src/helpers/resource/components/__tests__/ResourceLoader.test.js
+++ b/src/helpers/resource/components/__tests__/ResourceLoader.test.js
@@ -64,6 +64,37 @@ test('auto loads detail and renders results', async () => {
   await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
 })
 
+test('loads detail successfully and updates status object', async () => {
+  mockApi.onGet('/user/1').reply(200, {id: 1, name: 'Ben'})
+
+  // Renders ResourceLoader component with statusView from renderInitial prop.
+  const {getByTestId} = renderWithRedux(
+    <ResourceLoader resource="user" resourceId={1} list={false}>
+      {({status, onEventLoadResource}) => (
+        <div>
+          <button onClick={onEventLoadResource} data-testid="load-resource">
+            Load Resource
+          </button>
+          {status.initial && <div data-testid="render-initial" />}
+          {status.error && <div data-testid="render-error" />}
+          {status.loading && <div data-testid="render-loading" />}
+          {status.success && <div data-testid="render-success" />}
+          {status.done && <div data-testid="render-done" />}
+        </div>
+      )}
+    </ResourceLoader>,
+  )
+
+  // Expects ResourceLoader component to render statusView from renderInitial.
+  expect(getByTestId('render-initial')).toBeInTheDOM()
+
+  // Simulating a button click in the browser and go through status changes
+  Simulate.click(getByTestId('load-resource'))
+  await wait(() => expect(getByTestId('render-loading')).toBeInTheDOM())
+  await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
+  expect(getByTestId('render-done')).toBeInTheDOM()
+})
+
 test('auto loads list and renders results', async () => {
   mockApi
     .onGet('/user')

--- a/src/helpers/resource/components/__tests__/ResourceLoader.test.js
+++ b/src/helpers/resource/components/__tests__/ResourceLoader.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 // eslint-disable-next-line
 import 'dom-testing-library/extend-expect'
 import React from 'react'


### PR DESCRIPTION
Add a new `done` property to the status object that is passed to the child
render prop of ResourceLoader. This new status property indicates the request is
finished which means `error` or `success` are true.

Also updated `react-redux` to get rid of the React 16.3 lifecycle warnings:

```
warning.js:33 Warning: Unsafe legacy lifecycles will not be called for components using new component APIs.

Connect(ResourceLoader) uses getDerivedStateFromProps() but also contains the following legacy lifecycles:
  componentWillReceiveProps
  componentWillUpdate

The above lifecycles should be removed. Learn more about this warning here:
```