### PR TITLE
feat(release): ResourceLoader re-render on every parent render

### DIFF
--- a/src/helpers/resource/components/ResourceLoader.js
+++ b/src/helpers/resource/components/ResourceLoader.js
@@ -219,4 +219,6 @@ const mapDispatchToProps = {
 export default connect(
   null,
   mapDispatchToProps,
+  null,
+  {pure: false},
 )(ResourceLoader)

--- a/src/helpers/resource/components/ResourceLoader.js
+++ b/src/helpers/resource/components/ResourceLoader.js
@@ -172,16 +172,19 @@ class ResourceLoader extends React.Component {
     const {entityType} = this.props
     const {result, ...requestResultValues} = this.getRequesResultValuesObj()
 
-    return this.props.children({
-      onEventLoadResource: this.onEventLoadResource,
-      loadResource: this.loadResource,
-      status: this.getStatusObj(),
-      statusView: this.getStatusView(),
-      error,
-      entityType,
-      result,
-      ...requestResultValues,
-    })
+    return this.props.children(
+      {
+        onEventLoadResource: this.onEventLoadResource,
+        loadResource: this.loadResource,
+        status: this.getStatusObj(),
+        statusView: this.getStatusView(),
+        error,
+        entityType,
+        result,
+        ...requestResultValues,
+      },
+      this.props.passThru,
+    )
   }
 }
 
@@ -201,6 +204,7 @@ ResourceLoader.propTypes = {
   requestParams: PropTypes.object,
   resource: PropTypes.string.isRequired,
   resourceId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  passThru: PropTypes.any,
 }
 
 // Polyfill component so the new lifecycles will work with older React versions

--- a/src/helpers/resource/components/__tests__/NestedResourceLoader.test.js
+++ b/src/helpers/resource/components/__tests__/NestedResourceLoader.test.js
@@ -1,0 +1,136 @@
+/* eslint-disable complexity */
+// eslint-disable-next-line
+import 'dom-testing-library/extend-expect'
+import React from 'react'
+import {Simulate, wait} from 'react-testing-library'
+import ResourceLoader from '../ResourceLoader'
+import {mockApi, renderWithRedux} from '../../../../utils/test'
+import {
+  // DetailResourceLoaderTester,
+  InstrumentAllStatuses,
+  // Status,
+} from './helpers/ResourceLoader'
+
+const delayReply = ({delay, response}) => config => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve(response)
+    }, delay)
+  })
+}
+
+test('renders nested ResourceLoader', async () => {
+  mockApi.onGet('/user/1').reply(200, {id: 1, name: 'Ben'})
+  mockApi.onGet('/user/2').reply(200, {id: 2, name: 'Tom'})
+
+  const {getByTestId} = renderWithRedux(
+    <ResourceLoader resource="user" resourceId={1} list={false} autoLoad>
+      {userOne => (
+        <ResourceLoader resource="user" resourceId={2} list={false} autoLoad>
+          {userTwo => (
+            <div>
+              <InstrumentAllStatuses status={userOne.status} label="one" />
+              <InstrumentAllStatuses status={userTwo.status} label="two" />
+
+              {userOne.status.success && (
+                <div>
+                  <div data-testid="one-id">{userOne.result.id}</div>
+                  <div data-testid="one-name">{userOne.result.name}</div>
+                </div>
+              )}
+
+              {userTwo.status.success && (
+                <div>
+                  <div data-testid="two-id">{userTwo.result.id}</div>
+                  <div data-testid="two-name">{userTwo.result.name}</div>
+                </div>
+              )}
+            </div>
+          )}
+        </ResourceLoader>
+      )}
+    </ResourceLoader>,
+  )
+
+  // --
+  // -- 1. Initial mount and begin loading BOTH resources
+  // --
+  expect(getByTestId('one-status-loading')).toBeInTheDOM()
+  expect(getByTestId('two-status-loading')).toBeInTheDOM()
+
+  // --
+  // -- 2. The second request (two) should finish before the first (one)
+  // --
+  await wait(() => expect(getByTestId('two-status-success')).toBeInTheDOM())
+  expect(getByTestId('one-status-success')).toBeInTheDOM()
+
+  // --
+  // -- 2. Both results should be properly loaded
+  // --
+  expect(getByTestId('one-id')).toHaveTextContent('1')
+  expect(getByTestId('one-name')).toHaveTextContent('Ben')
+
+  expect(getByTestId('two-id')).toHaveTextContent('2')
+  expect(getByTestId('two-name')).toHaveTextContent('Tom')
+})
+
+test('renders nested ResourceLoader with first request returns after second', async () => {
+  // make the first request rerurn after the second
+  mockApi
+    .onGet('/user/1')
+    .reply(delayReply({delay: 300, response: [200, {id: 1, name: 'Ben'}]}))
+
+  mockApi
+    .onGet('/user/2')
+    .reply(delayReply({delay: 100, response: [200, {id: 2, name: 'Tom'}]}))
+
+  const {getByTestId} = renderWithRedux(
+    <ResourceLoader resource="user" resourceId={1} list={false} autoLoad>
+      {userOne => (
+        <ResourceLoader resource="user" resourceId={2} list={false} autoLoad>
+          {userTwo => (
+            <div>
+              <InstrumentAllStatuses status={userOne.status} label="one" />
+              <InstrumentAllStatuses status={userTwo.status} label="two" />
+
+              {userOne.status.success && (
+                <div>
+                  <div data-testid="one-id">{userOne.result.id}</div>
+                  <div data-testid="one-name">{userOne.result.name}</div>
+                </div>
+              )}
+
+              {userTwo.status.success && (
+                <div>
+                  <div data-testid="two-id">{userTwo.result.id}</div>
+                  <div data-testid="two-name">{userTwo.result.name}</div>
+                </div>
+              )}
+            </div>
+          )}
+        </ResourceLoader>
+      )}
+    </ResourceLoader>,
+  )
+
+  // --
+  // -- 1. Initial mount and begin loading BOTH resources
+  // --
+  expect(getByTestId('one-status-loading')).toBeInTheDOM()
+  expect(getByTestId('two-status-loading')).toBeInTheDOM()
+
+  // --
+  // -- 2. The second request (two) should finish before the first (one)
+  // --
+  await wait(() => expect(getByTestId('one-status-success')).toBeInTheDOM())
+  expect(getByTestId('two-status-success')).toBeInTheDOM()
+
+  // --
+  // -- 2. Both results should be properly loaded
+  // --
+  expect(getByTestId('one-id')).toHaveTextContent('1')
+  expect(getByTestId('one-name')).toHaveTextContent('Ben')
+
+  expect(getByTestId('two-id')).toHaveTextContent('2')
+  expect(getByTestId('two-name')).toHaveTextContent('Tom')
+})

--- a/src/helpers/resource/components/__tests__/NestedResourceLoader.test.js
+++ b/src/helpers/resource/components/__tests__/NestedResourceLoader.test.js
@@ -2,12 +2,14 @@
 // eslint-disable-next-line
 import 'dom-testing-library/extend-expect'
 import React from 'react'
-import {Simulate, wait} from 'react-testing-library'
+import {wait} from 'react-testing-library'
 import ResourceLoader from '../ResourceLoader'
 import {mockApi, renderWithRedux} from '../../../../utils/test'
 import {InstrumentAllStatuses} from './helpers/ResourceLoader'
 
+// eslint-disable-next-line no-unused-vars
 const delayReply = ({delay, response}) => config => {
+  // eslint-disable-next-line no-unused-vars
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve(response)

--- a/src/helpers/resource/components/__tests__/helpers/ResourceLoader.js
+++ b/src/helpers/resource/components/__tests__/helpers/ResourceLoader.js
@@ -78,3 +78,31 @@ Status.propTypes = {
   error: PropTypes.bool,
   success: PropTypes.bool,
 }
+
+export function InstrumentAllStatuses({status, label = 'label'}) {
+  return (
+    <div>
+      <InstrumentStatus status={status} label={label} type="initial" />
+      <InstrumentStatus status={status} label={label} type="loading" />
+      <InstrumentStatus status={status} label={label} type="error" />
+      <InstrumentStatus status={status} label={label} type="success" />
+      <InstrumentStatus status={status} label={label} type="done" />
+    </div>
+  )
+}
+
+InstrumentAllStatuses.propTypes = {
+  status: PropTypes.object.isRequired,
+  label: PropTypes.string,
+}
+
+function InstrumentStatus({status, label, type}) {
+  if (!status[type]) return null
+  return <div data-testid={`${label}-status-${type}`} />
+}
+
+InstrumentStatus.propTypes = {
+  status: PropTypes.object.isRequired,
+  label: PropTypes.string,
+  type: PropTypes.string,
+}


### PR DESCRIPTION
To support nested ResourceLoaders we needed to block react-redux's `connect`
pure render use of shouldComponentUpdate. In the future we may want to make this
optional.