### PR TITLE
feat: Block auto camelization of keys w/ _ prefix

### DIFF
--- a/src/utils/__tests__/index.test.js
+++ b/src/utils/__tests__/index.test.js
@@ -3,11 +3,14 @@ import {camelKeys, snakeKeys} from '../index'
 /* eslint-disable camelcase */
 describe('camelKeys', () => {
   test.each`
-    source                | expected
-    ${{test_one: 1}}      | ${{testOne: 1}}
-    ${{'test-two': 2}}    | ${{'test-two': 2}}
-    ${{'a1b2C-three': 3}} | ${{'a1b2C-three': 3}}
-    ${{'a1b2C-Four': 4}}  | ${{'a1b2C-Four': 4}}
+    source                      | expected
+    ${{test_one: 1}}            | ${{testOne: 1}}
+    ${{'test-two': 2}}          | ${{'test-two': 2}}
+    ${{'a1b2C-three': 3}}       | ${{'a1b2C-three': 3}}
+    ${{'a1b2C-Four': 4}}        | ${{'a1b2C-Four': 4}}
+    ${{_prefix_one: 'p1'}}      | ${{_prefix_one: 'p1'}}
+    ${{__prefixTwo: 'p2'}}      | ${{__prefixTwo: 'p2'}}
+    ${{'__prefix-three': 'p3'}} | ${{'__prefix-three': 'p3'}}
   `(
     'returns $expected when camelKeys is passed $source',
     ({source, expected}) => {
@@ -18,11 +21,14 @@ describe('camelKeys', () => {
 
 describe('snakeKeys', () => {
   test.each`
-    source                | expected
-    ${{testOne: 1}}       | ${{test_one: 1}}
-    ${{'test-two': 2}}    | ${{'test-two': 2}}
-    ${{'a1b2C-three': 3}} | ${{'a1b2C-three': 3}}
-    ${{'a1b2C-Four': 4}}  | ${{'a1b2C-Four': 4}}
+    source                      | expected
+    ${{testOne: 1}}             | ${{test_one: 1}}
+    ${{'test-two': 2}}          | ${{'test-two': 2}}
+    ${{'a1b2C-three': 3}}       | ${{'a1b2C-three': 3}}
+    ${{'a1b2C-Four': 4}}        | ${{'a1b2C-Four': 4}}
+    ${{_prefix_one: 'p1'}}      | ${{_prefix_one: 'p1'}}
+    ${{__prefixTwo: 'p2'}}      | ${{__prefixTwo: 'p2'}}
+    ${{'__prefix-three': 'p3'}} | ${{'__prefix-three': 'p3'}}
   `(
     'returns $expected when snakeKeys is passed $source',
     ({source, expected}) => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -20,17 +20,26 @@ export class RdxModResourceError extends BaseError {}
 // -- object key formating
 // --
 
+export const isCamelSafe = str => /^[A-Za-z0-9_]+$/.test(str)
+export const hasLodashPrefix = str => /^_/.test(str)
+
 export const camelKeys = obj =>
-  camelizeKeys(
-    obj,
-    (key, convert) => (/^[A-Za-z0-9_]+$/.test(key) ? convert(key) : key),
-  )
+  camelizeKeys(obj, (key, convert) => {
+    if (!isCamelSafe(key) || hasLodashPrefix(key)) {
+      return key
+    }
+
+    return convert(key)
+  })
+
 export const snakeKeys = obj =>
-  decamelizeKeys(
-    obj,
-    (key, convert, options) =>
-      /^[A-Za-z0-9_]+$/.test(key) ? convert(key, options) : key,
-  )
+  decamelizeKeys(obj, (key, convert, options) => {
+    if (!isCamelSafe(key) || hasLodashPrefix(key)) {
+      return key
+    }
+
+    return convert(key, options)
+  })
 
 // --
 // -- General Utils


### PR DESCRIPTION
When resources are loaded the keys of the data in the response body are
automatically camelCased (converted from snake_case). This commit causes keys
with an underscore as the first character to NOT be camelCased and left alone.