### PR TITLE
feat: ResourceLoader `updateResource` callback

### DIFF
--- a/src/helpers/resource/components/ResourceLoader.js
+++ b/src/helpers/resource/components/ResourceLoader.js
@@ -6,6 +6,7 @@ import {
   resourceDetailReadRequest,
   resourceListCreateRequest,
   resourceListReadRequest,
+  resourceUpdateRequest,
 } from '../../../modules/resource/actions'
 
 class ResourceLoader extends React.Component {
@@ -103,6 +104,14 @@ class ResourceLoader extends React.Component {
     )
   }
 
+  updateResource = data => {
+    this.setState({loading: true})
+    this.requestResourceDetailUpdate(data).then(
+      this.loadResourceSuccess,
+      this.loadResourceError,
+    )
+  }
+
   loadResourceAutomatically = () => {
     if (this.props.autoLoad) {
       this.loadResource()
@@ -137,12 +146,17 @@ class ResourceLoader extends React.Component {
   requestResource = params => {
     return this.props.list
       ? this.requestResourceList(params)
-      : this.requestResourceDetail(params)
+      : this.requestResourceDetailRead(params)
   }
 
-  requestResourceDetail = () => {
+  requestResourceDetailRead = () => {
     const {requestDetailRead, resource, resourceId, entityType} = this.props
     return requestDetailRead(resource, resourceId, entityType)
+  }
+
+  requestResourceDetailUpdate = data => {
+    const {requestDetailUpdate, resource, resourceId, entityType} = this.props
+    return requestDetailUpdate(resource, resourceId, data, entityType)
   }
 
   requestResourceList = dynamicParams => {
@@ -176,6 +190,7 @@ class ResourceLoader extends React.Component {
       {
         onEventLoadResource: this.onEventLoadResource,
         loadResource: this.loadResource,
+        updateResource: this.updateResource,
         status: this.getStatusObj(),
         statusView: this.getStatusView(),
         error,
@@ -199,6 +214,7 @@ ResourceLoader.propTypes = {
   renderLoading: PropTypes.func,
   renderSuccess: PropTypes.func,
   requestDetailRead: PropTypes.func,
+  requestDetailUpdate: PropTypes.func,
   requestListCreate: PropTypes.func,
   requestListRead: PropTypes.func,
   requestParams: PropTypes.object,
@@ -212,6 +228,7 @@ polyfill(ResourceLoader)
 
 const mapDispatchToProps = {
   requestDetailRead: resourceDetailReadRequest,
+  requestDetailUpdate: resourceUpdateRequest,
   requestListCreate: resourceListCreateRequest,
   requestListRead: resourceListReadRequest,
 }


### PR DESCRIPTION
ResourceLoader now passes `updateResource` function in the bag it passes to child render prop. This new function triggers a resourceUpdateRequest (PUT) for the resource it is setup to load. The `updateResource` takes a single argument `data` which is the payload sent in the request. This new function should make it easy to load a resource on page load and then send updates (saves) to the backend with the response updating the data rendered in the success view or child render prop.

Example Usage:

```jsx
<ResourceDetailLoader
  resource="user"
  resourceId={1}
  renderSuccess={user => <p>{user.name}</p>}
  autoLoad
>
  {({result: user, statusView, updateResource}) => (
    <div>
      {statusView}
      <button onClick={() => updateResource({...user, name: 'Ben'})}>
        Update User
      </button>
    </div>
  )}
</ResourceDetailLoader>
```


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added `updateResource` function to the ResourceLoader's child render prop
function args for updating resources easily.

<!-- Why are these changes necessary? -->

**Why**:

Because I want to avoid custom actions where ever whenever.

<!-- How were these changes implemented? -->

**How**:

Manned up and typed code.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->