### PR TITLE
feat: ResourceLoader request triggers action ONLY

### DIFF
--- a/src/helpers/resource/components/ResourceLoader.js
+++ b/src/helpers/resource/components/ResourceLoader.js
@@ -190,7 +190,9 @@ class ResourceLoader extends React.Component {
       {
         onEventLoadResource: this.onEventLoadResource,
         loadResource: this.loadResource,
+        loadResourceRequest: this.requestResource,
         updateResource: this.updateResource,
+        updateResourceRequest: this.requestResourceDetailUpdate,
         status: this.getStatusObj(),
         statusView: this.getStatusView(),
         error,

--- a/src/helpers/resource/components/__tests__/ResourceLoaderTriggeredRequests.test.js
+++ b/src/helpers/resource/components/__tests__/ResourceLoaderTriggeredRequests.test.js
@@ -1,0 +1,189 @@
+/* eslint-disable complexity */
+// eslint-disable-next-line
+import 'dom-testing-library/extend-expect'
+import React from 'react'
+import {Simulate, wait} from 'react-testing-library'
+import ResourceLoader from '../ResourceLoader'
+import {api, mockApi, renderWithRedux} from '../../../../utils/test'
+import {Status} from './helpers/ResourceLoader'
+
+test('error loading detail and updates status object', async () => {
+  mockApi.onGet('/user/1').reply(500)
+
+  const {getByTestId} = renderWithRedux(
+    <ResourceLoader resource="user" resourceId={1} list={false}>
+      {({result, status, onEventLoadResource: onClick}) => (
+        <div>
+          <button onClick={onClick} data-testid="load-resource">
+            Load Resource
+          </button>
+          <code>{JSON.stringify(result, null, 2)}</code>
+          {status.initial && <div data-testid="render-initial" />}
+          {status.error && <div data-testid="render-error" />}
+          {status.loading && <div data-testid="render-loading" />}
+          {status.success && <div data-testid="render-success" />}
+          {status.done && <div data-testid="render-done" />}
+        </div>
+      )}
+    </ResourceLoader>,
+  )
+
+  expect(getByTestId('render-initial')).toBeInTheDOM()
+
+  Simulate.click(getByTestId('load-resource'))
+
+  await wait(() => expect(getByTestId('render-loading')).toBeInTheDOM())
+  await wait(() => expect(getByTestId('render-error')).toBeInTheDOM())
+  expect(getByTestId('render-done')).toBeInTheDOM()
+})
+
+test('makes resource requests using the child render request functions', async () => {
+  const user = {id: 'a', name: 'Ben'}
+  const userPut = {id: 'a', name: 'Tom'}
+
+  mockApi.onGet('/user/a').reply(200, user)
+  mockApi.onPut('/user/a', userPut).reply(200, userPut)
+
+  const spyApiGet = jest.spyOn(api, 'get')
+  const spyApiPut = jest.spyOn(api, 'put')
+
+  // eslint-disable-next-line
+  const UserTap = ({id, name}) => (
+    <Status success>
+      {id}:{name}
+    </Status>
+  )
+
+  const {getByTestId, getByText} = renderWithRedux(
+    <ResourceLoader
+      resource="user"
+      resourceId="a"
+      renderInitial={() => <Status initial />}
+      renderError={error => (
+        <Status error>{JSON.stringify(error, null, 2)}</Status>
+      )}
+      renderLoading={() => <Status loading />}
+      renderSuccess={({id, name}) => <UserTap {...{id, name}} />}
+      list={false}
+    >
+      {({
+        statusView,
+        onEventLoadResource,
+        loadResource,
+        loadResourceRequest,
+        updateResource,
+        updateResourceRequest,
+      }) => {
+        const doLoadResource = () => loadResource()
+        const doLoadResourceRequest = () => loadResourceRequest()
+        const doUpdateResource = () => updateResource(userPut)
+        const doUpdateResourceRequest = () => updateResourceRequest(userPut)
+        return (
+          <div>
+            <button onClick={onEventLoadResource}>OnEventLoadResource</button>
+            <button onClick={doLoadResource}>LoadResource</button>
+            <button onClick={doLoadResourceRequest}>LoadResourceRequest</button>
+            <button onClick={doUpdateResource}>UpdateResource</button>
+            <button onClick={doUpdateResourceRequest}>
+              UpdateResourceRequest
+            </button>
+            {statusView}
+          </div>
+        )
+      }}
+    </ResourceLoader>,
+  )
+
+  // Expects ResourceLoader component to render statusView from renderInitial.
+  expect(getByTestId('render-initial')).toHaveTextContent('Initial')
+
+  // --
+  // -- 1. `onEventLoadResource` triggers load resource request
+  // --
+  Simulate.click(getByText('OnEventLoadResource'))
+  expect(getByTestId('render-loading')).toHaveTextContent('Loading')
+  await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
+  expect(getByTestId('render-success')).toHaveTextContent('a:Ben')
+
+  // --
+  // -- 2. `loadResource` triggers load resource request
+  // --
+  Simulate.click(getByText('LoadResource'))
+  expect(getByTestId('render-loading')).toHaveTextContent('Loading')
+  await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
+  expect(getByTestId('render-success')).toHaveTextContent('a:Ben')
+
+  // --
+  // -- 3. `updateResource` triggers update resource request
+  // --
+  Simulate.click(getByText('UpdateResource'))
+  expect(getByTestId('render-loading')).toHaveTextContent('Loading')
+  await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
+  expect(getByTestId('render-success')).toHaveTextContent('a:Tom')
+
+  // --
+  // -- 4. `loadResourceRequest` triggers load resource request ONLY no status changes
+  // --
+  Simulate.click(getByText('LoadResourceRequest'))
+
+  // --
+  // -- 5. `updateResourceRequest` triggers update resource request ONLY no status changes
+  // --
+  Simulate.click(getByText('UpdateResourceRequest'))
+
+  expect(spyApiGet).toHaveBeenCalledTimes(3)
+  expect(spyApiPut).toHaveBeenCalledTimes(2)
+})
+
+test('auto loads and then makes update resource when updateResource called', async () => {
+  const userBen = {id: 1, name: 'Ben'}
+  const userSam = {...userBen, name: 'Sammy'}
+  mockApi.onGet('/user/1').reply(200, userBen)
+  mockApi.onPut('/user/1', userSam).reply(200, userSam)
+
+  // Renders ResourceLoader component with statusView from renderInitial prop.
+  const {getByTestId, getByText} = renderWithRedux(
+    <ResourceLoader
+      resource="user"
+      resourceId={1}
+      renderInitial={() => <Status initial />}
+      renderError={error => (
+        <Status error>{JSON.stringify(error, null, 2)}</Status>
+      )}
+      renderLoading={() => <Status loading />}
+      renderSuccess={user => (
+        <Status success>
+          {user.id}:{user.name}
+        </Status>
+      )}
+      list={false}
+      autoLoad
+    >
+      {({statusView, updateResource}) => (
+        <div>
+          <button
+            onClick={() => updateResource({...userSam})}
+            data-testid="update-resource"
+          >
+            Update Resource
+          </button>
+          {statusView}
+        </div>
+      )}
+    </ResourceLoader>,
+  )
+
+  // await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
+  await wait(() => {
+    expect(getByTestId('render-success')).toBeInTheDOM()
+    expect(getByTestId('render-success')).toHaveTextContent('1:Ben')
+  })
+
+  Simulate.click(getByText('Update Resource'))
+  expect(getByTestId('render-loading')).toBeInTheDOM()
+
+  await wait(() => {
+    expect(getByTestId('render-success')).toBeInTheDOM()
+    expect(getByTestId('render-success')).toHaveTextContent('1:Sam')
+  })
+})


### PR DESCRIPTION
Added new functions `loadResourceRequest` and `updateResourceRequest` which dispatch the actions used in `loadResource` and `updateResource` and returns the redux-saga-thunk promise returned.

This makes it possible to request the resource without making the component change status states. Since it returns the redux-saga-thunk promise success and error handling is easily accessible.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->