### PR TITLE
fix: Resource detail read (GET) params support

### DIFF
--- a/src/helpers/__tests__/resource.js
+++ b/src/helpers/__tests__/resource.js
@@ -176,8 +176,8 @@ describe('resourceDetailRead', () => {
     'action',
     opts => {
       const {action} = resourceDetailRead(opts.resource, opts.entitiy)
-      expect(action(opts.payload)).toEqual(
-        expectActions(opts.resource, opts.payload, opts.entitiy),
+      expect(action(opts.payload, opts.params)).toEqual(
+        expectActions(opts.resource, opts.payload, opts.params, opts.entitiy),
       )
     },
     {
@@ -185,10 +185,21 @@ describe('resourceDetailRead', () => {
         resource: 'team',
         payload: {id: 1, title: 'Team 1'},
       },
+      'resource ONLY (no entitiy) w/ params': {
+        resource: 'team',
+        payload: {id: 1, title: 'Team 1'},
+        params: {flag: 1},
+      },
       'resource & entitiy': {
         resource: 'team',
         entitiy: 'team',
         payload: {id: 1, title: 'Team 2'},
+      },
+      'resource & entitiy w/ params': {
+        resource: 'team',
+        entitiy: 'team',
+        payload: {id: 1, title: 'Team 2'},
+        params: {flag: 1},
       },
     },
   )

--- a/src/helpers/resource/components/ResourceLoader.js
+++ b/src/helpers/resource/components/ResourceLoader.js
@@ -146,12 +146,18 @@ class ResourceLoader extends React.Component {
   requestResource = params => {
     return this.props.list
       ? this.requestResourceList(params)
-      : this.requestResourceDetailRead(params)
+      : this.requestResourceDetail(params)
   }
 
-  requestResourceDetailRead = () => {
+  requestResourceDetail = dynamicParams => {
+    const {requestParams} = this.props
+    const params = {...requestParams, ...dynamicParams}
+    return this.requestResourceDetailRead(params)
+  }
+
+  requestResourceDetailRead = params => {
     const {requestDetailRead, resource, resourceId, entityType} = this.props
-    return requestDetailRead(resource, resourceId, entityType)
+    return requestDetailRead(resource, resourceId, params, entityType)
   }
 
   requestResourceDetailUpdate = data => {
@@ -161,7 +167,7 @@ class ResourceLoader extends React.Component {
 
   requestResourceList = dynamicParams => {
     const {postRequest, requestParams} = this.props
-    const params = {...dynamicParams, ...requestParams}
+    const params = {...requestParams, ...dynamicParams}
     return postRequest
       ? this.requestResourceListCreate(params)
       : this.requestResourceListRead(params)

--- a/src/helpers/resource/index.js
+++ b/src/helpers/resource/index.js
@@ -59,8 +59,8 @@ export default ({entities, resource}) => {
   )
 
   const resourceDetailRead = createHelper(
-    (resourcePath, entityType) => needle =>
-      resourceDetailReadRequest(resourcePath, needle, entityType),
+    (resourcePath, entityType) => (needle, params) =>
+      resourceDetailReadRequest(resourcePath, needle, params, entityType),
     resourcePath => `${resourcePath}DetailRead`,
     resource.selectors.getDetail,
     entities.selectors.getDetail,

--- a/src/modules/resource/__tests__/actions.test.js
+++ b/src/modules/resource/__tests__/actions.test.js
@@ -235,11 +235,14 @@ test('resourceListReadFailure', () => {
 // --
 
 test('resourceDetailReadRequest', () => {
-  expect(actions.resourceDetailReadRequest('resourceName', 1)).toEqual(
+  expect(
+    actions.resourceDetailReadRequest('resourceName', 1, {flag: 1}),
+  ).toEqual(
     expect.objectContaining({
       type: actions.RESOURCE_DETAIL_READ_REQUEST,
       payload: {
         needle: 1,
+        params: {flag: 1},
       },
       meta: expect.objectContaining({
         resource: 'resourceName',

--- a/src/modules/resource/__tests__/sagas.test.js
+++ b/src/modules/resource/__tests__/sagas.test.js
@@ -97,13 +97,13 @@ describe('readResourceList', () => {
 })
 
 describe('readResourceDetail', () => {
-  const payload = {needle: 1}
+  const payload = {needle: 1, params: {flag: 1}}
 
   it('calls success', () => {
     const detail = 'foo'
     const generator = sagas.readResourceDetail(api, payload, meta)
     expect(generator.next().value).toEqual(
-      call([api, api.get], `/${resource}/1`),
+      call([api, api.get], `/${resource}/1`, payload.params),
     )
     expect(generator.next({data: detail}).value).toEqual(
       put(
@@ -121,7 +121,7 @@ describe('readResourceDetail', () => {
   it('calls failure', () => {
     const generator = sagas.readResourceDetail(api, payload, meta)
     expect(generator.next().value).toEqual(
-      call([api, api.get], `/${resource}/1`),
+      call([api, api.get], `/${resource}/1`, payload.params),
     )
     expect(generator.throw('test').value).toEqual(
       put(

--- a/src/modules/resource/actions.js
+++ b/src/modules/resource/actions.js
@@ -164,9 +164,14 @@ export const RESOURCE_DETAIL_READ_REQUEST = 'RESOURCE_DETAIL_READ_REQUEST'
 export const RESOURCE_DETAIL_READ_SUCCESS = 'RESOURCE_DETAIL_READ_SUCCESS'
 export const RESOURCE_DETAIL_READ_FAILURE = 'RESOURCE_DETAIL_READ_FAILURE'
 
-export const resourceDetailReadRequest = (resource, needle, entityType) => ({
+export const resourceDetailReadRequest = (
+  resource,
+  needle,
+  params,
+  entityType,
+) => ({
   type: RESOURCE_DETAIL_READ_REQUEST,
-  payload: {needle},
+  payload: {needle, params},
   meta: {
     entityType,
     resource,

--- a/src/modules/resource/sagas.js
+++ b/src/modules/resource/sagas.js
@@ -98,20 +98,21 @@ export function* readResourceList(
 
 export function* readResourceDetail(
   api,
-  {needle},
+  {needle, params},
   {resource, thunk, entityType},
 ) {
   try {
     const resp = yield call(
       [api, api.get],
       resourceNeedlePath(resource, needle),
+      params,
     )
     yield put(
       actions.resourceDetailReadSuccess(
         resource,
         entityType,
         apiResponseToPayload(resp),
-        {needle},
+        {needle, params},
         thunk,
       ),
     )
@@ -121,7 +122,7 @@ export function* readResourceDetail(
         resource,
         entityType,
         camelKeys(e),
-        {needle},
+        {needle, params},
         thunk,
       ),
     )


### PR DESCRIPTION
When passing the `requestParams` prop to ResourceLoader component for loading data no params were included. This fixes that allowing loading data with GET params.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->