### PR TITLE
fix: loadResource & updateResource promise

### DIFF
--- a/src/helpers/resource/components/ResourceLoader.js
+++ b/src/helpers/resource/components/ResourceLoader.js
@@ -40,6 +40,11 @@ class ResourceLoader extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    // Sets this false so we can prevent setState after unmount
+    this.requestingResource = false
+  }
+
   getRequesResultValuesObj() {
     const {requestResult} = this.state
     const entities = requestResult && requestResult.entities
@@ -97,16 +102,18 @@ class ResourceLoader extends React.Component {
   }
 
   loadResource = params => {
+    this.requestingResource = true
     this.setState({loading: true})
-    this.requestResource(params).then(
+    return this.requestResource(params).then(
       this.loadResourceSuccess,
       this.loadResourceError,
     )
   }
 
   updateResource = data => {
+    this.requestingResource = true
     this.setState({loading: true})
-    this.requestResourceDetailUpdate(data).then(
+    return this.requestResourceDetailUpdate(data).then(
       this.loadResourceSuccess,
       this.loadResourceError,
     )
@@ -131,11 +138,15 @@ class ResourceLoader extends React.Component {
       resource: payload.resource,
     }
 
-    this.setState({
-      requestResult,
-      error: null,
-      loading: false,
-    })
+    if (this.requestingResource) {
+      this.requestingResource = false
+
+      this.setState({
+        requestResult,
+        error: null,
+        loading: false,
+      })
+    }
   }
 
   onEventLoadResource = e => {

--- a/src/helpers/resource/components/__tests__/ResourceListLoader.test.js
+++ b/src/helpers/resource/components/__tests__/ResourceListLoader.test.js
@@ -53,3 +53,31 @@ test('auto loads list and renders results', async () => {
    */
   await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
 })
+
+test('auto loads list with POST request and renders results', async () => {
+  mockApi.onPost('/user').reply(200, [{id: 1, name: 'Ben'}])
+
+  // Renders ResourceListLoader component with statusView from renderInitial prop.
+  const {getByTestId} = renderWithRedux(
+    <ResourceListLoader
+      resource="user"
+      renderInitial={() => <Status initial />}
+      renderError={error => <Status error>{error}</Status>}
+      renderLoading={() => <Status loading />}
+      renderSuccess={userList => <Status success>{`${userList}`}</Status>}
+      autoLoad
+      postRequest
+    >
+      {({statusView}) => <div>{statusView}</div>}
+    </ResourceListLoader>,
+  )
+  expect(getByTestId('render-loading')).toHaveTextContent('Loading')
+
+  /*  'wait' method waits (4500ms by default) until a callback
+   *  function stops throwing an error. It is being checked
+   *  at 50ms intervals.
+   *
+   *  Waiting for renderSuccess to show in DOM
+   */
+  await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
+})

--- a/src/helpers/resource/components/__tests__/ResourceLoader.test.js
+++ b/src/helpers/resource/components/__tests__/ResourceLoader.test.js
@@ -21,6 +21,20 @@ test('throws error if child prop not function', () => {
   }).toThrow()
 })
 
+test('component unmounts', () => {
+  const {container, unmount} = renderWithRedux(
+    <ResourceLoader
+      resource="example"
+      renderInitial={() => <Status initial />}
+      list={false}
+    >
+      {({statusView}) => statusView}
+    </ResourceLoader>,
+  )
+  unmount()
+  expect(container.innerHTML).toBe('')
+})
+
 test('receives props and renders initial statusView', () => {
   const {getByTestId} = renderWithRedux(
     <ResourceLoader

--- a/src/helpers/resource/components/__tests__/ResourceLoaderTriggeredRequests.test.js
+++ b/src/helpers/resource/components/__tests__/ResourceLoaderTriggeredRequests.test.js
@@ -87,9 +87,6 @@ test('makes resource requests using the child render request functions', async (
         const doLoadResource = () => locker.put('loadResource', loadResource())
         const doLoadResourceRequest = () =>
           locker.put('loadResourceRequest', loadResourceRequest())
-        // const doLoadResourceRequest = () => loadResourceRequest()
-        // const doUpdateResource = () => updateResource(userPut)
-        // const doUpdateResourceRequest = () => updateResourceRequest(userPut)
         const doUpdateResource = () =>
           locker.put('updateResource', updateResource(userPut))
         const doUpdateResourceRequest = () =>

--- a/src/helpers/resource/components/__tests__/ResourceLoaderTriggeredRequests.test.js
+++ b/src/helpers/resource/components/__tests__/ResourceLoaderTriggeredRequests.test.js
@@ -7,6 +7,14 @@ import ResourceLoader from '../ResourceLoader'
 import {api, mockApi, renderWithRedux} from '../../../../utils/test'
 import {Status} from './helpers/ResourceLoader'
 
+const testLocker = () => {
+  const vals = {}
+  return {
+    put: (name, value) => (vals[name] = value),
+    get: name => vals[name],
+  }
+}
+
 test('error loading detail and updates status object', async () => {
   mockApi.onGet('/user/1').reply(500)
 
@@ -54,6 +62,8 @@ test('makes resource requests using the child render request functions', async (
     </Status>
   )
 
+  const locker = testLocker()
+
   const {getByTestId, getByText} = renderWithRedux(
     <ResourceLoader
       resource="user"
@@ -74,10 +84,16 @@ test('makes resource requests using the child render request functions', async (
         updateResource,
         updateResourceRequest,
       }) => {
-        const doLoadResource = () => loadResource()
-        const doLoadResourceRequest = () => loadResourceRequest()
-        const doUpdateResource = () => updateResource(userPut)
-        const doUpdateResourceRequest = () => updateResourceRequest(userPut)
+        const doLoadResource = () => locker.put('loadResource', loadResource())
+        const doLoadResourceRequest = () =>
+          locker.put('loadResourceRequest', loadResourceRequest())
+        // const doLoadResourceRequest = () => loadResourceRequest()
+        // const doUpdateResource = () => updateResource(userPut)
+        // const doUpdateResourceRequest = () => updateResourceRequest(userPut)
+        const doUpdateResource = () =>
+          locker.put('updateResource', updateResource(userPut))
+        const doUpdateResourceRequest = () =>
+          locker.put('updateResourceRequest', updateResourceRequest(userPut))
         return (
           <div>
             <button onClick={onEventLoadResource}>OnEventLoadResource</button>
@@ -133,6 +149,14 @@ test('makes resource requests using the child render request functions', async (
 
   expect(spyApiGet).toHaveBeenCalledTimes(3)
   expect(spyApiPut).toHaveBeenCalledTimes(2)
+
+  // --
+  // -- 6. confirm triggers return a promise (from redux-saga-thunk)
+  // --
+  expect(locker.get('loadResource')).toBeInstanceOf(Promise)
+  expect(locker.get('loadResourceRequest')).toBeInstanceOf(Promise)
+  expect(locker.get('updateResource')).toBeInstanceOf(Promise)
+  expect(locker.get('updateResourceRequest')).toBeInstanceOf(Promise)
 })
 
 test('auto loads and then makes update resource when updateResource called', async () => {


### PR DESCRIPTION
The redux-saga-thunk promise wasn't being returned from the `loadResource` and `updateResource` functions passed into the child render prop of ResourceLoader component. This fix now returns promise which can be used to respond to async resource request.

Also added a guard to prevent updating state after ResourceLoader unmounts.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->