### PR TITLE
feat: Support custom camel/snake case predicates

### DIFF
--- a/src/modules/resource/__tests__/index.test.js
+++ b/src/modules/resource/__tests__/index.test.js
@@ -1,8 +1,8 @@
 import createSagaMiddleware from 'redux-saga'
 import {createStore, applyMiddleware} from 'redux'
+import createSagas from '../sagas'
 import {delay} from '../../../utils'
 import reducer from '../reducer'
-import sagas from '../sagas'
 import {getList, getDetail} from '../selectors'
 import {
   resourceCreateRequest,
@@ -13,6 +13,7 @@ import {
 } from '../actions'
 
 const sagaMiddleware = createSagaMiddleware()
+const {rootSaga} = createSagas()
 
 const api = {
   post: (path, data) => Promise.resolve({data}),
@@ -27,7 +28,7 @@ const getStore = initialState => {
     initialState,
     applyMiddleware(sagaMiddleware),
   )
-  sagaMiddleware.run(sagas, {api})
+  sagaMiddleware.run(rootSaga, {api})
   return store
 }
 

--- a/src/modules/resource/__tests__/sagas.test.js
+++ b/src/modules/resource/__tests__/sagas.test.js
@@ -1,6 +1,8 @@
 import {put, call} from 'redux-saga/effects'
 import * as actions from '../actions'
-import * as sagas from '../sagas'
+import createSagas from '../sagas'
+
+const sagas = createSagas()
 
 const api = {
   post: () => {},

--- a/src/modules/resource/index.js
+++ b/src/modules/resource/index.js
@@ -1,14 +1,20 @@
 import {isolateSelectorsState} from '../../utils'
+import createSagas from './sagas'
 import * as actions from './actions'
 import * as selectors from './selectors'
 import reducer from './reducer'
-import sagas from './sagas'
 
-export default ({storeName = 'resource'} = {}) => {
+export default ({
+  storeName = 'resource',
+  camelCaseKeyPred,
+  snakeCaseKeyPred,
+} = {}) => {
+  const {rootSaga} = createSagas({camelCaseKeyPred, snakeCaseKeyPred})
+
   return {
     actions,
     reducer,
-    sagas,
+    sagas: rootSaga,
     selectors: isolateSelectorsState(storeName, selectors),
   }
 }

--- a/src/modules/resource/sagas.js
+++ b/src/modules/resource/sagas.js
@@ -1,240 +1,265 @@
 import {takeEvery, put, call} from 'redux-saga/effects'
-import {camelKeys, snakeKeys, consoleErrorRecovery, safeSaga} from '../../utils'
+import {
+  createCamelKeys,
+  createSnakeKeys,
+  consoleErrorRecovery,
+  safeSaga,
+} from '../../utils'
 import * as actions from './actions'
 
-export const resourceNeedlePath = (resource, needle) => {
-  if (!needle) return `/${resource}`
-  return `/${resource}/${needle}`
-}
-export const apiResponseData = response => camelKeys(response.data)
+const sagasFactory = ({
+  // Function to customize auto camelCasing response data keys
+  camelCaseKeyPred,
+  // Function to customize auto snake_casing request data keys
+  snakeCaseKeyPred,
+} = {}) => {
+  const camelKeys = createCamelKeys(camelCaseKeyPred)
+  const snakeKeys = createSnakeKeys(snakeCaseKeyPred)
 
-export const apiResponseToPayload = response => ({
-  api: {response},
-  data: apiResponseData(response),
-})
+  const resourceNeedlePath = (resource, needle) => {
+    if (!needle) return `/${resource}`
+    return `/${resource}/${needle}`
+  }
+  const apiResponseData = response => camelKeys(response.data)
 
-export function* createResource(api, {data}, {resource, thunk, entityType}) {
-  try {
-    const resp = yield call([api, api.post], `/${resource}`, snakeKeys(data))
-    const action = actions.resourceCreateSuccess(
-      resource,
-      entityType,
-      apiResponseToPayload(resp),
-      {data},
-      thunk,
-    )
-    yield put(action)
-  } catch (e) {
-    yield put(
-      actions.resourceCreateFailure(
+  const apiResponseToPayload = response => ({
+    api: {response},
+    data: apiResponseData(response),
+  })
+
+  function* createResource(api, {data}, {resource, thunk, entityType}) {
+    try {
+      const resp = yield call([api, api.post], `/${resource}`, snakeKeys(data))
+      const action = actions.resourceCreateSuccess(
         resource,
         entityType,
-        camelKeys(e),
+        apiResponseToPayload(resp),
         {data},
         thunk,
-      ),
-    )
+      )
+      yield put(action)
+    } catch (e) {
+      yield put(
+        actions.resourceCreateFailure(
+          resource,
+          entityType,
+          camelKeys(e),
+          {data},
+          thunk,
+        ),
+      )
+    }
   }
-}
 
-export function* createResourceList(
-  api,
-  {data},
-  {resource, thunk, entityType},
-) {
-  const params = snakeKeys(data)
-  try {
-    const resp = yield call([api, api.post], `/${resource}`, params)
-    const action = actions.resourceListCreateSuccess(
-      resource,
-      entityType,
-      apiResponseToPayload(resp),
-      params,
-      thunk,
-    )
-    yield put(action)
-  } catch (e) {
-    yield put(
-      actions.resourceListCreateFailure(
-        resource,
-        entityType,
-        camelKeys(e),
-        data,
-        thunk,
-      ),
-    )
-  }
-}
-
-export function* readResourceList(
-  api,
-  {params},
-  {resource, thunk, entityType},
-) {
-  try {
-    const resp = yield call([api, api.get], `/${resource}`, params)
-
-    yield put(
-      actions.resourceListReadSuccess(
+  function* createResourceList(api, {data}, {resource, thunk, entityType}) {
+    const params = snakeKeys(data)
+    try {
+      const resp = yield call([api, api.post], `/${resource}`, params)
+      const action = actions.resourceListCreateSuccess(
         resource,
         entityType,
         apiResponseToPayload(resp),
-        {params},
+        params,
         thunk,
-      ),
+      )
+      yield put(action)
+    } catch (e) {
+      yield put(
+        actions.resourceListCreateFailure(
+          resource,
+          entityType,
+          camelKeys(e),
+          data,
+          thunk,
+        ),
+      )
+    }
+  }
+
+  function* readResourceList(api, {params}, {resource, thunk, entityType}) {
+    try {
+      const resp = yield call([api, api.get], `/${resource}`, params)
+
+      yield put(
+        actions.resourceListReadSuccess(
+          resource,
+          entityType,
+          apiResponseToPayload(resp),
+          {params},
+          thunk,
+        ),
+      )
+    } catch (e) {
+      yield put(
+        actions.resourceListReadFailure(
+          resource,
+          entityType,
+          camelKeys(e),
+          {params},
+          thunk,
+        ),
+      )
+    }
+  }
+
+  function* readResourceDetail(
+    api,
+    {needle, params},
+    {resource, thunk, entityType},
+  ) {
+    try {
+      const resp = yield call(
+        [api, api.get],
+        resourceNeedlePath(resource, needle),
+        params,
+      )
+      yield put(
+        actions.resourceDetailReadSuccess(
+          resource,
+          entityType,
+          apiResponseToPayload(resp),
+          {needle, params},
+          thunk,
+        ),
+      )
+    } catch (e) {
+      yield put(
+        actions.resourceDetailReadFailure(
+          resource,
+          entityType,
+          camelKeys(e),
+          {needle, params},
+          thunk,
+        ),
+      )
+    }
+  }
+
+  function* updateResource(api, {needle, data}, {resource, thunk, entityType}) {
+    try {
+      const resp = yield call(
+        [api, api.put],
+        resourceNeedlePath(resource, needle),
+        snakeKeys(data),
+      )
+      yield put(
+        actions.resourceUpdateSuccess(
+          resource,
+          entityType,
+          apiResponseToPayload(resp),
+          {needle, data},
+          thunk,
+        ),
+      )
+    } catch (e) {
+      yield put(
+        actions.resourceUpdateFailure(
+          resource,
+          entityType,
+          camelKeys(e),
+          {needle, data},
+          thunk,
+        ),
+      )
+    }
+  }
+
+  function* deleteResource(api, {needle}, {resource, thunk, entityType}) {
+    try {
+      yield call([api, api.delete], resourceNeedlePath(resource, needle))
+      yield put(
+        actions.resourceDeleteSuccess(resource, entityType, {needle}, thunk),
+      )
+    } catch (e) {
+      yield put(
+        actions.resourceDeleteFailure(
+          resource,
+          entityType,
+          camelKeys(e),
+          {needle},
+          thunk,
+        ),
+      )
+    }
+  }
+
+  function* watchResourceCreateRequest(api, {payload, meta}) {
+    yield call(createResource, api, payload, meta)
+  }
+
+  function* watchResourceListCreateRequest(api, {payload, meta}) {
+    yield call(createResourceList, api, payload, meta)
+  }
+
+  function* watchResourceListReadRequest(api, {payload, meta}) {
+    yield call(readResourceList, api, payload, meta)
+  }
+
+  function* watchResourceDetailReadRequest(api, {payload, meta}) {
+    yield call(readResourceDetail, api, payload, meta)
+  }
+
+  function* watchResourceUpdateRequest(api, {payload, meta}) {
+    yield call(updateResource, api, payload, meta)
+  }
+
+  function* watchResourceDeleteRequest(api, {payload, meta}) {
+    yield call(deleteResource, api, payload, meta)
+  }
+
+  function* rootSaga({api}) {
+    const safe = safeSaga(consoleErrorRecovery)
+
+    yield takeEvery(
+      actions.RESOURCE_CREATE_REQUEST,
+      safe(watchResourceCreateRequest, api),
     )
-  } catch (e) {
-    yield put(
-      actions.resourceListReadFailure(
-        resource,
-        entityType,
-        camelKeys(e),
-        {params},
-        thunk,
-      ),
+
+    yield takeEvery(
+      actions.RESOURCE_LIST_CREATE_REQUEST,
+      safe(watchResourceListCreateRequest, api),
     )
+
+    yield takeEvery(
+      actions.RESOURCE_LIST_READ_REQUEST,
+      safe(watchResourceListReadRequest, api),
+    )
+
+    yield takeEvery(
+      actions.RESOURCE_DETAIL_READ_REQUEST,
+      safe(watchResourceDetailReadRequest, api),
+    )
+
+    yield takeEvery(
+      actions.RESOURCE_UPDATE_REQUEST,
+      safe(watchResourceUpdateRequest, api),
+    )
+
+    yield takeEvery(
+      actions.RESOURCE_DELETE_REQUEST,
+      safe(watchResourceDeleteRequest, api),
+    )
+  }
+
+  return {
+    apiResponseData,
+    apiResponseToPayload,
+    createResource,
+    createResourceList,
+    deleteResource,
+    readResourceDetail,
+    readResourceList,
+    resourceNeedlePath,
+    updateResource,
+    watchResourceCreateRequest,
+    watchResourceDeleteRequest,
+    watchResourceDetailReadRequest,
+    watchResourceListCreateRequest,
+    watchResourceListReadRequest,
+    watchResourceUpdateRequest,
+
+    rootSaga,
   }
 }
 
-export function* readResourceDetail(
-  api,
-  {needle, params},
-  {resource, thunk, entityType},
-) {
-  try {
-    const resp = yield call(
-      [api, api.get],
-      resourceNeedlePath(resource, needle),
-      params,
-    )
-    yield put(
-      actions.resourceDetailReadSuccess(
-        resource,
-        entityType,
-        apiResponseToPayload(resp),
-        {needle, params},
-        thunk,
-      ),
-    )
-  } catch (e) {
-    yield put(
-      actions.resourceDetailReadFailure(
-        resource,
-        entityType,
-        camelKeys(e),
-        {needle, params},
-        thunk,
-      ),
-    )
-  }
-}
-
-export function* updateResource(
-  api,
-  {needle, data},
-  {resource, thunk, entityType},
-) {
-  try {
-    const resp = yield call(
-      [api, api.put],
-      resourceNeedlePath(resource, needle),
-      snakeKeys(data),
-    )
-    yield put(
-      actions.resourceUpdateSuccess(
-        resource,
-        entityType,
-        apiResponseToPayload(resp),
-        {needle, data},
-        thunk,
-      ),
-    )
-  } catch (e) {
-    yield put(
-      actions.resourceUpdateFailure(
-        resource,
-        entityType,
-        camelKeys(e),
-        {needle, data},
-        thunk,
-      ),
-    )
-  }
-}
-
-export function* deleteResource(api, {needle}, {resource, thunk, entityType}) {
-  try {
-    yield call([api, api.delete], resourceNeedlePath(resource, needle))
-    yield put(
-      actions.resourceDeleteSuccess(resource, entityType, {needle}, thunk),
-    )
-  } catch (e) {
-    yield put(
-      actions.resourceDeleteFailure(
-        resource,
-        entityType,
-        camelKeys(e),
-        {needle},
-        thunk,
-      ),
-    )
-  }
-}
-
-export function* watchResourceCreateRequest(api, {payload, meta}) {
-  yield call(createResource, api, payload, meta)
-}
-
-export function* watchResourceListCreateRequest(api, {payload, meta}) {
-  yield call(createResourceList, api, payload, meta)
-}
-
-export function* watchResourceListReadRequest(api, {payload, meta}) {
-  yield call(readResourceList, api, payload, meta)
-}
-
-export function* watchResourceDetailReadRequest(api, {payload, meta}) {
-  yield call(readResourceDetail, api, payload, meta)
-}
-
-export function* watchResourceUpdateRequest(api, {payload, meta}) {
-  yield call(updateResource, api, payload, meta)
-}
-
-export function* watchResourceDeleteRequest(api, {payload, meta}) {
-  yield call(deleteResource, api, payload, meta)
-}
-
-export default function*({api}) {
-  const safe = safeSaga(consoleErrorRecovery)
-
-  yield takeEvery(
-    actions.RESOURCE_CREATE_REQUEST,
-    safe(watchResourceCreateRequest, api),
-  )
-
-  yield takeEvery(
-    actions.RESOURCE_LIST_CREATE_REQUEST,
-    safe(watchResourceListCreateRequest, api),
-  )
-
-  yield takeEvery(
-    actions.RESOURCE_LIST_READ_REQUEST,
-    safe(watchResourceListReadRequest, api),
-  )
-
-  yield takeEvery(
-    actions.RESOURCE_DETAIL_READ_REQUEST,
-    safe(watchResourceDetailReadRequest, api),
-  )
-
-  yield takeEvery(
-    actions.RESOURCE_UPDATE_REQUEST,
-    safe(watchResourceUpdateRequest, api),
-  )
-
-  yield takeEvery(
-    actions.RESOURCE_DELETE_REQUEST,
-    safe(watchResourceDeleteRequest, api),
-  )
-}
+export default sagasFactory

--- a/src/utils/__tests__/index.test.js
+++ b/src/utils/__tests__/index.test.js
@@ -1,7 +1,9 @@
-import {camelKeys, snakeKeys} from '../index'
+import {createCamelKeys, createSnakeKeys} from '../index'
 
 /* eslint-disable camelcase */
 describe('camelKeys', () => {
+  const camelKeys = createCamelKeys()
+
   test.each`
     source                      | expected
     ${{test_one: 1}}            | ${{testOne: 1}}
@@ -19,7 +21,38 @@ describe('camelKeys', () => {
   )
 })
 
+describe('camelKeys - prevent matrixValues pred', () => {
+  const customPred = (key, obj, isSafe) => {
+    // use original key if it's `matrixValues`
+    if (key === 'matrix-values') return false
+
+    // key has ! at end inverse typical behavior
+    if (key.endsWith('!')) return !isSafe
+
+    // Fall back to default conversion
+    return null
+  }
+
+  const camelKeys = createCamelKeys(customPred)
+  test.each`
+    source                       | expected
+    ${{'matrix-values': 1}}      | ${{'matrix-values': 1}}
+    ${{'invertSafe!': 2}}        | ${{'invertSafe!': 2}}
+    ${{'invert-not_safe!': 3}}   | ${{'invertNotSafe!': 3}}
+    ${{'a1b2C-Four': 4}}         | ${{'a1b2C-Four': 4}}
+    ${{_prefix_one: 'p1'}}       | ${{_prefix_one: 'p1'}}
+    ${{__prefixTwo: 'p2'}}       | ${{__prefixTwo: 'p2'}}
+    ${{'__prefix-three!': 'p3'}} | ${{'prefixThree!': 'p3'}}
+  `(
+    'returns $expected when camelKeys is passed $source',
+    ({source, expected}) => {
+      expect(camelKeys(source)).toEqual(expected)
+    },
+  )
+})
+
 describe('snakeKeys', () => {
+  const snakeKeys = createSnakeKeys()
   test.each`
     source                      | expected
     ${{testOne: 1}}             | ${{test_one: 1}}
@@ -29,6 +62,36 @@ describe('snakeKeys', () => {
     ${{_prefix_one: 'p1'}}      | ${{_prefix_one: 'p1'}}
     ${{__prefixTwo: 'p2'}}      | ${{__prefixTwo: 'p2'}}
     ${{'__prefix-three': 'p3'}} | ${{'__prefix-three': 'p3'}}
+  `(
+    'returns $expected when snakeKeys is passed $source',
+    ({source, expected}) => {
+      expect(snakeKeys(source)).toEqual(expected)
+    },
+  )
+})
+
+describe('snakeKeys - prevent matrixValues pred', () => {
+  const customPred = (key, obj, isSafe) => {
+    // use original key if it's `matrixValues`
+    if (key === 'matrixValues') return false
+
+    // key has ! at end inverse typical behavior
+    if (key.endsWith('!')) return !isSafe
+
+    // Fall back to default conversion
+    return null
+  }
+
+  const snakeKeys = createSnakeKeys(customPred)
+  test.each`
+    source                       | expected
+    ${{matrixValues: 1}}         | ${{matrixValues: 1}}
+    ${{'invertSafe!': 2}}        | ${{'invertSafe!': 2}}
+    ${{'invert-notSafe!': 3}}    | ${{'invert-not_safe!': 3}}
+    ${{'a1b2C-Four': 4}}         | ${{'a1b2C-Four': 4}}
+    ${{_prefix_one: 'p1'}}       | ${{_prefix_one: 'p1'}}
+    ${{__prefixTwo: 'p2'}}       | ${{__prefixTwo: 'p2'}}
+    ${{'__prefix-three!': 'p3'}} | ${{'__prefix-three!': 'p3'}}
   `(
     'returns $expected when snakeKeys is passed $source',
     ({source, expected}) => {


### PR DESCRIPTION
This allows you to provide a predicate function to customize how:

  * Resource REQUEST response data's keys are auto cameCased Resource RESPONSE data's keys are auto snake_cased

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [*] Tests
* [*] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->