### PR TITLE
feat(ResourceLoader): Add delete/DELETE support

### DIFF
--- a/src/helpers/resource/components/ResourceLoader.js
+++ b/src/helpers/resource/components/ResourceLoader.js
@@ -4,6 +4,7 @@ import {polyfill} from 'react-lifecycles-compat'
 import {connect} from 'react-redux'
 import {
   resourceCreateRequest,
+  resourceDeleteRequest,
   resourceDetailReadRequest,
   resourceListCreateRequest,
   resourceListReadRequest,
@@ -109,6 +110,11 @@ class ResourceLoader extends React.Component {
     return this.loadResourceAsync(request)
   }
 
+  deleteResource = deleteId => {
+    const request = this.requestResourceDetailDelete(deleteId)
+    return this.loadResourceAsync(request)
+  }
+
   loadResourceAsync(requestPromise) {
     this._asyncActive = true
     this.setState({loading: true})
@@ -181,6 +187,12 @@ class ResourceLoader extends React.Component {
     return requestDetailCreate(resource, data, entityType)
   }
 
+  requestResourceDetailDelete = deleteId => {
+    const {requestDetailDelete, resource, resourceId, entityType} = this.props
+    const finalDeleteId = deleteId === undefined ? resourceId : deleteId
+    return requestDetailDelete(resource, finalDeleteId, entityType)
+  }
+
   requestResourceDetailRead = params => {
     const {requestDetailRead, resource, resourceId, entityType} = this.props
     return requestDetailRead(resource, resourceId, params, entityType)
@@ -223,6 +235,8 @@ class ResourceLoader extends React.Component {
         onEventLoadResource: this.onEventLoadResource,
         createResource: this.createResource,
         createResourceRequest: this.requestResourceDetailCreate,
+        deleteResource: this.deleteResource,
+        deleteResourceRequest: this.requestResourceDetailDelete,
         loadResource: this.loadResource,
         loadResourceRequest: this.requestResource,
         updateResource: this.updateResource,
@@ -250,6 +264,7 @@ ResourceLoader.propTypes = {
   renderLoading: PropTypes.func,
   renderSuccess: PropTypes.func,
   requestDetailCreate: PropTypes.func.isRequired,
+  requestDetailDelete: PropTypes.func.isRequired,
   requestDetailRead: PropTypes.func.isRequired,
   requestDetailUpdate: PropTypes.func.isRequired,
   requestListCreate: PropTypes.func.isRequired,
@@ -265,6 +280,7 @@ polyfill(ResourceLoader)
 
 const mapDispatchToProps = {
   requestDetailCreate: resourceCreateRequest,
+  requestDetailDelete: resourceDeleteRequest,
   requestDetailRead: resourceDetailReadRequest,
   requestDetailUpdate: resourceUpdateRequest,
   requestListCreate: resourceListCreateRequest,

--- a/src/helpers/resource/components/__tests__/ResourceLoaderTriggeredRequests.test.js
+++ b/src/helpers/resource/components/__tests__/ResourceLoaderTriggeredRequests.test.js
@@ -98,32 +98,24 @@ test('makes resource GET requests using the child render request functions', asy
   // Expects ResourceLoader component to render statusView from renderInitial.
   expect(getByTestId('render-initial')).toHaveTextContent('Initial')
 
-  // --
-  // -- 1. `onEventLoadResource` triggers load resource request
-  // --
+  // `onEventLoadResource` triggers load resource request
   Simulate.click(getByText('OnEventLoadResource'))
   expect(getByTestId('render-loading')).toHaveTextContent('Loading')
   await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
   expect(getByTestId('render-success')).toHaveTextContent('a:Ben')
 
-  // --
-  // -- 2. `loadResource` triggers load resource request
-  // --
+  // `loadResource` triggers load resource request
   Simulate.click(getByText('LoadResource'))
   expect(getByTestId('render-loading')).toHaveTextContent('Loading')
   await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
   expect(getByTestId('render-success')).toHaveTextContent('a:Ben')
 
-  // --
-  // -- 5. Triggers resource requests ONLY no status changes
-  // --
+  // -- Triggers resource requests ONLY no status changes
   Simulate.click(getByText('LoadResourceRequest'))
 
   expect(spyApiGet).toHaveBeenCalledTimes(3)
 
-  // --
-  // -- 6. confirm triggers return a promise (from redux-saga-thunk)
-  // --
+  // -- confirm triggers return a promise (from redux-saga-thunk)
   expect(locker.get('loadResource')).toBeInstanceOf(Promise)
   expect(locker.get('loadResourceRequest')).toBeInstanceOf(Promise)
 })
@@ -243,6 +235,64 @@ test('makes resource PUT requests using the child render request functions', asy
   // confirm triggers return a promise (from redux-saga-thunk)
   expect(locker.get('updateResource')).toBeInstanceOf(Promise)
   expect(locker.get('updateResourceRequest')).toBeInstanceOf(Promise)
+})
+
+test('makes resource DELETE requests using the child render request functions', async () => {
+  const userDelete = {id: 'a', name: 'Tom'}
+  mockApi.onDelete('/user/a', userDelete).reply(204)
+  const spyApiDelete = jest.spyOn(api, 'delete')
+  const locker = testLocker()
+
+  const {getByTestId, getByText} = renderWithRedux(
+    <ResourceLoader
+      resource="user"
+      resourceId="a"
+      renderInitial={() => <Status initial />}
+      renderError={error => (
+        <Status error>{JSON.stringify(error, null, 2)}</Status>
+      )}
+      renderLoading={() => <Status loading />}
+      renderSuccess={({id, name}) => <UserTap {...{id, name}} />}
+      list={false}
+    >
+      {({statusView, deleteResource, deleteResourceRequest}) => {
+        // Delete Resurce
+        const doDeleteResource = () =>
+          locker.put('deleteResource', deleteResource(userDelete))
+        const doDeleteResourceRequest = () =>
+          locker.put('deleteResourceRequest', deleteResourceRequest(userDelete))
+
+        return (
+          <div>
+            {/* Delete Resource */}
+            <button onClick={doDeleteResource}>DeleteResource</button>
+            <button onClick={doDeleteResourceRequest}>
+              DeleteResourceRequest
+            </button>
+            {statusView}
+          </div>
+        )
+      }}
+    </ResourceLoader>,
+  )
+
+  // Expects ResourceLoader component to render statusView from renderInitial.
+  expect(getByTestId('render-initial')).toHaveTextContent('Initial')
+
+  // `deleteResource` triggers delete resource request
+  Simulate.click(getByText('DeleteResource'))
+  expect(getByTestId('render-loading')).toHaveTextContent('Loading')
+  await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
+  expect(getByTestId('render-success')).toHaveTextContent('a:Tom')
+
+  // Triggers resource requests ONLY no status changes
+  Simulate.click(getByText('DeleteResourceRequest'))
+
+  expect(spyApiDelete).toHaveBeenCalledTimes(2)
+
+  // confirm triggers return a promise (from redux-saga-thunk)
+  expect(locker.get('deleteResource')).toBeInstanceOf(Promise)
+  expect(locker.get('deleteResourceRequest')).toBeInstanceOf(Promise)
 })
 
 test('auto loads and then makes update resource when updateResource called', async () => {

--- a/src/helpers/resource/components/__tests__/ResourceLoaderTriggeredRequests.test.js
+++ b/src/helpers/resource/components/__tests__/ResourceLoaderTriggeredRequests.test.js
@@ -252,15 +252,18 @@ test('makes resource DELETE requests using the child render request functions', 
         <Status error>{JSON.stringify(error, null, 2)}</Status>
       )}
       renderLoading={() => <Status loading />}
-      renderSuccess={({id, name}) => <UserTap {...{id, name}} />}
+      renderSuccess={() => <UserTap id="a" name="Dead" />}
       list={false}
     >
       {({statusView, deleteResource, deleteResourceRequest}) => {
         // Delete Resurce
         const doDeleteResource = () =>
-          locker.put('deleteResource', deleteResource(userDelete))
+          locker.put('deleteResource', deleteResource(userDelete.id))
         const doDeleteResourceRequest = () =>
-          locker.put('deleteResourceRequest', deleteResourceRequest(userDelete))
+          locker.put(
+            'deleteResourceRequest',
+            deleteResourceRequest(userDelete.id),
+          )
 
         return (
           <div>
@@ -283,7 +286,7 @@ test('makes resource DELETE requests using the child render request functions', 
   Simulate.click(getByText('DeleteResource'))
   expect(getByTestId('render-loading')).toHaveTextContent('Loading')
   await wait(() => expect(getByTestId('render-success')).toBeInTheDOM())
-  expect(getByTestId('render-success')).toHaveTextContent('a:Tom')
+  expect(getByTestId('render-success')).toHaveTextContent('a:Dead')
 
   // Triggers resource requests ONLY no status changes
   Simulate.click(getByText('DeleteResourceRequest'))


### PR DESCRIPTION
Added `deleteResource` and `deleteResourceRequest` for manually triggering DELETE requests.

The only argument `deleteResource` and `deleteResourceRequest` take is `deleteId`. This will set the resourceId used for the DELETE request, otherwise it uses the resourceId set on `resourceId` prop.