### PR TITLE
Fix entities update merging old and new value

### DIFF
--- a/src/helpers/resource/components/__tests__/ResourceLoader.test.js
+++ b/src/helpers/resource/components/__tests__/ResourceLoader.test.js
@@ -129,7 +129,9 @@ test('auto loads list and renders results', async () => {
       renderLoading={() => <Status loading />}
       renderSuccess={userList => (
         <Status success>
-          {userList.map(user => <div key={user.id}>{user.name}</div>)}
+          {userList.map(user => (
+            <div key={user.id}>{user.name}</div>
+          ))}
         </Status>
       )}
       autoLoad
@@ -160,7 +162,9 @@ test('auto loads with params passed in', async () => {
       renderLoading={() => <Status loading />}
       renderSuccess={userList => (
         <Status success>
-          {userList.map(user => <div key={user.id}>{user.name}</div>)}
+          {userList.map(user => (
+            <div key={user.id}>{user.name}</div>
+          ))}
         </Status>
       )}
       requestParams={{best: 'dude'}}
@@ -263,7 +267,9 @@ test('post resource request and renders results', async () => {
       renderLoading={() => <Status loading />}
       renderSuccess={userList => (
         <Status success>
-          {userList.map(user => <div key={user.id}>{user.name}</div>)}
+          {userList.map(user => (
+            <div key={user.id}>{user.name}</div>
+          ))}
         </Status>
       )}
       autoLoad

--- a/src/modules/entities/__tests__/reducer.test.js
+++ b/src/modules/entities/__tests__/reducer.test.js
@@ -9,8 +9,15 @@ const reducer = createReducer({initialState})
 const altState = {
   ...initialState,
   foo: {
-    id: 1,
-    bars: [1, 2, 3],
+    1: {
+      id: 1,
+      bars: [1, 2, 3],
+    },
+  },
+  bar: {
+    1: {type: 'ape', food: 'bananas'},
+    2: {type: 'cat', food: 'fish'},
+    3: {type: 'doc', food: 'meat'},
   },
 }
 
@@ -18,20 +25,50 @@ test('returns the initial state', () => {
   expect(reducer(undefined, {})).toEqual(initialState)
 })
 
-test('handles recieving entities', () => {
+describe('handles recieving entities', () => {
   const createAction = payload => ({
     type: ENTITIES_RECEIVE,
     payload,
   })
-  expect(reducer(initialState, createAction({foo: altState.foo}))).toEqual(
-    altState,
-  )
-  expect(reducer(altState, createAction({foo: {bars: [4]}}))).toEqual({
-    ...altState,
-    foo: {
-      ...altState.foo,
-      bars: [4],
-    },
+
+  describe('normalized entities value', () => {
+    test('initial state', () => {
+      const payload = {foo: {1: {id: 1, bars: [2]}}}
+      expect(reducer(initialState, createAction(payload))).toEqual(payload)
+    })
+
+    test('existing state', () => {
+      const payload = {foo: {1: {id: 1, bars: [4]}}}
+      expect(reducer(altState, createAction(payload))).toEqual({
+        ...altState,
+        foo: {...altState.foo, ...payload.foo},
+      })
+    })
+  })
+
+  describe('non-normalized value', () => {
+    const payload = {bar: {1: {type: 'ant', food: 'chip'}}}
+    test('initial state', () => {
+      expect(reducer(initialState, createAction(payload))).toEqual(payload)
+    })
+    test('existing state', () => {
+      expect(reducer(altState, createAction(payload))).toEqual({
+        ...altState,
+        bar: {...altState.bar, ...payload.bar},
+      })
+    })
+  })
+  test('object value', () => {
+    expect(reducer(initialState, createAction({foo: altState.foo}))).toEqual({
+      foo: altState.foo,
+    })
+    expect(reducer(altState, createAction({foo: {bars: [4]}}))).toEqual({
+      ...altState,
+      foo: {
+        ...altState.foo,
+        bars: [4],
+      },
+    })
   })
 })
 

--- a/src/modules/entities/reducer.js
+++ b/src/modules/entities/reducer.js
@@ -1,16 +1,32 @@
-import mergeWith from 'lodash/mergeWith'
 import {dissocPath} from '../../utils/fp'
 import {ENTITIES_RECEIVE, ENTITIES_REMOVE} from './actions'
+
+/**
+ * Returns new state object updated to include new/updated entity values in
+ * payload.
+ *
+ * @arg {object} state Entities state
+ * @arg {object} updates Entities updates
+ * @returns {object} New state object updated to include entities from payload
+ *
+ */
+const updateEntities = (state, updates) => {
+  const newState = {...state}
+  Object.keys(updates).forEach(entityType => {
+    Object.keys(updates[entityType]).forEach(entityId => {
+      newState[entityType] = {
+        ...newState[entityType],
+        [entityId]: updates[entityType][entityId],
+      }
+    })
+  })
+  return newState
+}
 
 const reducerFactory = ({initialState}) => {
   return (state = initialState, {type, payload}) => {
     if (type === ENTITIES_RECEIVE) {
-      return mergeWith({}, state, payload, (objValue, srcValue) => {
-        if (Array.isArray(srcValue)) {
-          return srcValue
-        }
-        return undefined
-      })
+      return updateEntities(state, payload)
     }
 
     if (type === ENTITIES_REMOVE) {


### PR DESCRIPTION
Before this commit lodash's mergeWith was used which does a recursive
merge. This resulted in objects nested within an entity to retain items
that were removed in the updated value. This updates the the entities
reducer to replace entity value instead of merging the two together.

INFO: Dylan alerted me to this issue. He suggested entity updates should
always replace the old value nd never merge them. After investigating
the issue I conclude he was correct.