### PR TITLE
feat(entities): Update entities on DELETE resp status 200

### DIFF
--- a/src/modules/resource/__tests__/actions.test.js
+++ b/src/modules/resource/__tests__/actions.test.js
@@ -411,10 +411,13 @@ test('resourceDeleteRequest', () => {
 })
 
 test('resourceDeleteSuccess', () => {
+  const api = {response: {data: {id: 1, title: 'test'}}}
+  const payload = {api, data: api.response.data}
   expect(
     actions.resourceDeleteSuccess(
       'resourceName',
       'schemaName',
+      payload,
       'request',
       'thunk',
     ),
@@ -422,6 +425,7 @@ test('resourceDeleteSuccess', () => {
     expect.objectContaining({
       type: actions.RESOURCE_DELETE_SUCCESS,
       payload: {
+        ...payload,
         entityType: 'schemaName',
         resource: {
           path: 'resourceName',

--- a/src/modules/resource/__tests__/index.test.js
+++ b/src/modules/resource/__tests__/index.test.js
@@ -19,7 +19,7 @@ const api = {
   post: (path, data) => Promise.resolve({data}),
   get: () => Promise.resolve({data: [1, 2, 3]}),
   put: (path, data) => Promise.resolve({data}),
-  delete: () => Promise.resolve(),
+  delete: (path, data) => Promise.resolve({data}),
 }
 
 const getStore = initialState => {
@@ -106,9 +106,11 @@ describe('resource', () => {
     })
 
     expect(getList(getState(), 'resources')).toEqual([1, 2, {foo: 'bar'}])
+
     dispatch(resourceDeleteRequest('resources', 1))
     await delay()
     expect(getList(getState(), 'resources')).toEqual([2, {foo: 'bar'}])
+
     dispatch(resourceDeleteRequest('resources', {foo: 'bar'}))
     await delay()
     expect(getList(getState(), 'resources')).toEqual([2])

--- a/src/modules/resource/__tests__/sagas.test.js
+++ b/src/modules/resource/__tests__/sagas.test.js
@@ -187,12 +187,12 @@ describe('deleteResource', () => {
     expect(generator.next().value).toEqual(
       call([api, api.delete], `/${resource}/1`),
     )
-    expect(generator.next({status: 202}).value).toEqual(
+    expect(generator.next({status: 204}).value).toEqual(
       put(
         actions.resourceDeleteSuccess(
           resource,
           entityType,
-          sagas.apiResponseToPayload({status: 202}),
+          sagas.apiResponseToPayload({status: 204}),
           payload,
           thunk,
           false,

--- a/src/modules/resource/__tests__/sagas.test.js
+++ b/src/modules/resource/__tests__/sagas.test.js
@@ -8,7 +8,7 @@ const api = {
   post: () => {},
   get: () => {},
   put: () => {},
-  delete: () => {},
+  delete: (path, data) => Promise.resolve({data}),
 }
 
 const thunk = '123'
@@ -182,14 +182,41 @@ describe('updateResource', () => {
 
 describe('deleteResource', () => {
   const payload = {needle: 1}
-
-  it('calls success', () => {
+  it('calls success withOUT updates', () => {
     const generator = sagas.deleteResource(api, payload, meta)
     expect(generator.next().value).toEqual(
       call([api, api.delete], `/${resource}/1`),
     )
+    expect(generator.next({status: 202}).value).toEqual(
+      put(
+        actions.resourceDeleteSuccess(
+          resource,
+          entityType,
+          sagas.apiResponseToPayload({status: 202}),
+          payload,
+          thunk,
+          false,
+        ),
+      ),
+    )
+  })
+
+  it('calls success WITH UPDATES', () => {
+    const generator = sagas.deleteResource(api, payload, meta)
     expect(generator.next().value).toEqual(
-      put(actions.resourceDeleteSuccess(resource, entityType, payload, thunk)),
+      call([api, api.delete], `/${resource}/1`),
+    )
+    expect(generator.next({status: 200}).value).toEqual(
+      put(
+        actions.resourceDeleteSuccess(
+          resource,
+          entityType,
+          sagas.apiResponseToPayload({status: 200}),
+          payload,
+          thunk,
+          true,
+        ),
+      ),
     )
   })
 
@@ -248,11 +275,20 @@ test('watchResourceUpdateRequest', () => {
 })
 
 test('watchResourceDeleteRequest', () => {
-  const payload = {needle: 1}
-  const generator = sagas.watchResourceDeleteRequest(api, {payload, meta})
-  expect(generator.next({payload, meta}).value).toEqual(
-    call(sagas.deleteResource, api, payload, meta),
-  )
+  ;(() => {
+    const payload = {needle: 1}
+    const generator = sagas.watchResourceDeleteRequest(api, {payload, meta})
+    expect(generator.next({payload, meta}).value).toEqual(
+      call(sagas.deleteResource, api, payload, meta),
+    )
+  })()
+  ;(() => {
+    const payload = {needle: 2, data: {id: 3}}
+    const generator = sagas.watchResourceDeleteRequest(api, {payload, meta})
+    expect(generator.next({payload, meta}).value).toEqual(
+      call(sagas.deleteResource, api, payload, meta),
+    )
+  })()
 })
 
 // TODO re-enable these after we can mock safe sagas

--- a/src/modules/resource/actions.js
+++ b/src/modules/resource/actions.js
@@ -290,11 +290,14 @@ export const resourceDeleteRequest = (resource, needle, entityType) => ({
 export const resourceDeleteSuccess = (
   resource,
   entityType,
+  payload,
   request,
   thunk,
+  updateEntities,
 ) => ({
   type: RESOURCE_DELETE_SUCCESS,
   payload: {
+    ...payload,
     resource: {path: resource},
     entityType,
   },
@@ -303,7 +306,8 @@ export const resourceDeleteSuccess = (
     thunk,
     resource,
     entityType,
-    removeEntities: true,
+    removeEntities: !updateEntities,
+    normalizeEntities: updateEntities,
   },
 })
 

--- a/src/modules/resource/sagas.js
+++ b/src/modules/resource/sagas.js
@@ -167,9 +167,20 @@ const sagasFactory = ({
 
   function* deleteResource(api, {needle}, {resource, thunk, entityType}) {
     try {
-      yield call([api, api.delete], resourceNeedlePath(resource, needle))
+      const resp = yield call(
+        [api, api.delete],
+        resourceNeedlePath(resource, needle),
+      )
+
       yield put(
-        actions.resourceDeleteSuccess(resource, entityType, {needle}, thunk),
+        actions.resourceDeleteSuccess(
+          resource,
+          entityType,
+          apiResponseToPayload(resp),
+          {needle},
+          thunk,
+          resp.status === 200, // update on 200
+        ),
       )
     } catch (e) {
       yield put(


### PR DESCRIPTION
## Update entities on delete
Some APIs have DELETE endpoints that toggle a flag indicating an entity is deleted (aka "soft delete") rather than actually deleting the entity from the system. To support this the resourceDelete now updates existing entities rather than just remove them. If the API responds to a DELETE with a status 200 the response body is used to update entities the same way read requests do. Any non-error status returned by the DELETE endpoint results in the entity being removed (the behavior for all non-error statuses before this).

## 🚨 BREAKING CHANGE 🚨 
If a DELETE request returns a status 200 it will now try to update existing entities in memory/store. Our APIs return [204 No Content](https://tools.ietf.org/html/rfc7231#section-6.3.5) for standard delete and [200 OK](https://tools.ietf.org/html/rfc7231#section-6.3.1) for soft delete.